### PR TITLE
Use base image from ghcr.io and remove sha256

### DIFF
--- a/hello-helidon/helidon-app-greet-v1/Dockerfile
+++ b/hello-helidon/helidon-app-greet-v1/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, Oracle and/or its affiliates.
+# Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 FROM ghcr.io/oracle/oraclelinux:7-slim

--- a/hello-helidon/helidon-app-greet-v1/Dockerfile
+++ b/hello-helidon/helidon-app-greet-v1/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) 2020, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:fcc6f54bb01fc83319990bf5fa1b79f1dec93cbb87db3c5a8884a5a44148e7bb
+FROM ghcr.io/oracle/oraclelinux:7-slim
 
 RUN yum update -y && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \
     && yum install -y tar unzip gzip \


### PR DESCRIPTION
Per VZ-2198, change to pull the base image from ghcr.io and remove the sha256 in the hello-helidon v1 example Dockerfile.