### PR TITLE
Update base tag version to 0.14.0 (Same as the upcoming release)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
 
     parameters {
         string (name: 'BASE_TAG',
-                defaultValue: '0.1.12-1',
+                defaultValue: '0.14.0',
                 description: 'Base value used as part of generated image tag',
                 trim: true)
     }

--- a/bobs-books/bobs-bookstore-order-manager/deploy/imagetool-additions
+++ b/bobs-books/bobs-bookstore-order-manager/deploy/imagetool-additions
@@ -6,3 +6,7 @@ python-libs
 curl
 glibc
 glibc-common
+nss
+openldap
+nss-sysinit
+nss-tools


### PR DESCRIPTION
- Updates base tag version to 0.14.0 (Same as the upcoming release)
- Updates dependencies in bobs-bookstore-order-manager base image to remove vulnerabilities