### PR TITLE
VZ-2604: Bump dependencies

### DIFF
--- a/bobs-books/bobbys-books/bobbys-coherence/Dockerfile
+++ b/bobs-books/bobbys-books/bobbys-coherence/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:fcc6f54bb01fc83319990bf5fa1b79f1dec93cbb87db3c5a8884a5a44148e7bb
+FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:5fe1636f17bb1d100197d353f5d2f24a00dc201058386e7a428d2702602a6939
 
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \

--- a/bobs-books/bobbys-books/bobbys-coherence/Dockerfile
+++ b/bobs-books/bobbys-books/bobbys-coherence/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:5fe1636f17bb1d100197d353f5d2f24a00dc201058386e7a428d2702602a6939
+FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:84433cf4f605c35fa032ff87d2635c3ab5aaa7fbdb4bb8f90e60f4ab1b96d371
 
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \

--- a/bobs-books/bobbys-books/bobbys-front-end/pom.xml
+++ b/bobs-books/bobbys-books/bobbys-front-end/pom.xml
@@ -56,32 +56,32 @@
     <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-zipkin</artifactId>
-      <version>1.0.0</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-tracerresolver</artifactId>
-      <version>1.0.0</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-core</artifactId>
-      <version>1.0.0</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-client</artifactId>
-      <version>1.0.0</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-thrift</artifactId>
-      <version>1.0.0</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-micrometer</artifactId>
-      <version>1.0.0</version>
+      <version>1.6.0</version>
     </dependency>
     <dependency>
 	    <groupId>io.opentracing.contrib</groupId>

--- a/bobs-books/bobbys-books/bobbys-front-end/pom.xml
+++ b/bobs-books/bobbys-books/bobbys-front-end/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2020, 2021 Oracle and/or its affiliates. -->
+<!-- Copyright (c) 2020, 2021, Oracle and/or its affiliates. -->
 <!-- Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/bobs-books/bobbys-books/bobbys-front-end/pom.xml
+++ b/bobs-books/bobbys-books/bobbys-front-end/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2020, Oracle and/or its affiliates. -->
+<!-- Copyright (c) 2020, 2021 Oracle and/or its affiliates. -->
 <!-- Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/bobs-books/bobbys-books/bobbys-helidon-stock-application/Dockerfile
+++ b/bobs-books/bobbys-books/bobbys-helidon-stock-application/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:fcc6f54bb01fc83319990bf5fa1b79f1dec93cbb87db3c5a8884a5a44148e7bb
+FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:5fe1636f17bb1d100197d353f5d2f24a00dc201058386e7a428d2702602a6939
 
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \

--- a/bobs-books/bobbys-books/bobbys-helidon-stock-application/Dockerfile
+++ b/bobs-books/bobbys-books/bobbys-helidon-stock-application/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:5fe1636f17bb1d100197d353f5d2f24a00dc201058386e7a428d2702602a6939
+FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:84433cf4f605c35fa032ff87d2635c3ab5aaa7fbdb4bb8f90e60f4ab1b96d371
 
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \

--- a/bobs-books/bobs-bookstore-order-manager/deploy/build.sh
+++ b/bobs-books/bobs-bookstore-order-manager/deploy/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 scriptDir="$( cd "$( dirname $0 )" && pwd )"

--- a/bobs-books/bobs-bookstore-order-manager/deploy/build.sh
+++ b/bobs-books/bobs-bookstore-order-manager/deploy/build.sh
@@ -73,7 +73,7 @@ imagetool.sh create \
     --tag $1 \
     --version 12.2.1.4.0 \
     --jdkVersion 8u261 \
-    --fromImage container-registry.oracle.com/os/oraclelinux:7-slim@sha256:5fe1636f17bb1d100197d353f5d2f24a00dc201058386e7a428d2702602a6939 \
+    --fromImage container-registry.oracle.com/os/oraclelinux:7-slim@sha256:84433cf4f605c35fa032ff87d2635c3ab5aaa7fbdb4bb8f90e60f4ab1b96d371 \
     --wdtModel bobs-bookstore-topology.yaml \
     --wdtArchive archive.zip \
     --wdtVariables properties/docker-build/bobs-bookstore-topology.properties \

--- a/bobs-books/bobs-bookstore-order-manager/deploy/build.sh
+++ b/bobs-books/bobs-bookstore-order-manager/deploy/build.sh
@@ -73,7 +73,7 @@ imagetool.sh create \
     --tag $1 \
     --version 12.2.1.4.0 \
     --jdkVersion 8u261 \
-    --fromImage container-registry.oracle.com/os/oraclelinux:7-slim@sha256:fcc6f54bb01fc83319990bf5fa1b79f1dec93cbb87db3c5a8884a5a44148e7bb \
+    --fromImage container-registry.oracle.com/os/oraclelinux:7-slim@sha256:5fe1636f17bb1d100197d353f5d2f24a00dc201058386e7a428d2702602a6939 \
     --wdtModel bobs-bookstore-topology.yaml \
     --wdtArchive archive.zip \
     --wdtVariables properties/docker-build/bobs-bookstore-topology.properties \

--- a/bobs-books/roberts-books/roberts-coherence/Dockerfile
+++ b/bobs-books/roberts-books/roberts-coherence/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:fcc6f54bb01fc83319990bf5fa1b79f1dec93cbb87db3c5a8884a5a44148e7bb
+FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:5fe1636f17bb1d100197d353f5d2f24a00dc201058386e7a428d2702602a6939
 
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \

--- a/bobs-books/roberts-books/roberts-coherence/Dockerfile
+++ b/bobs-books/roberts-books/roberts-coherence/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:5fe1636f17bb1d100197d353f5d2f24a00dc201058386e7a428d2702602a6939
+FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:84433cf4f605c35fa032ff87d2635c3ab5aaa7fbdb4bb8f90e60f4ab1b96d371
 
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \

--- a/bobs-books/roberts-books/roberts-helidon-stock-application/Dockerfile
+++ b/bobs-books/roberts-books/roberts-helidon-stock-application/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:fcc6f54bb01fc83319990bf5fa1b79f1dec93cbb87db3c5a8884a5a44148e7bb
+FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:5fe1636f17bb1d100197d353f5d2f24a00dc201058386e7a428d2702602a6939
 
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \

--- a/bobs-books/roberts-books/roberts-helidon-stock-application/Dockerfile
+++ b/bobs-books/roberts-books/roberts-helidon-stock-application/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:5fe1636f17bb1d100197d353f5d2f24a00dc201058386e7a428d2702602a6939
+FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:84433cf4f605c35fa032ff87d2635c3ab5aaa7fbdb4bb8f90e60f4ab1b96d371
 
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \


### PR DESCRIPTION
Initially I just bumped a dependency in the bobbys-front-end example, but when I built my branch, a different image failed vuln scanning due to recent linux CVEs. So I bumped all of the OL 7-slim image digests to use the latest. I deployed all of the branch images to a local cluster and ran the Bob's Books acceptance test and all of the tests passed.

