### PR TITLE
Updates to robert-helidon-stock-application and todo-list

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -189,6 +189,8 @@ pipeline {
                         stage('Build Bobs Backend WebLogic Application') {
                             steps {
                                 sh """
+                                    # sleep 2 minutes to workaround WIT doing a docker prune at the same time
+                                    sleep 2m
                                     echo "${DOCKER_CREDS_PSW}" | docker login ghcr.io -u ${DOCKER_CREDS_USR} --password-stdin
                                     echo "${OCR_CREDS_PSW}" | docker login container-registry.oracle.com -u ${OCR_CREDS_USR} --password-stdin
                                     cd examples/bobs-books/bobs-bookstore-order-manager

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,6 +190,7 @@ pipeline {
                             steps {
                                 sh """
                                     # sleep 2 minutes to workaround WIT doing a docker prune at the same time
+                                    # once WIT has a fix this can be removed
                                     sleep 2m
                                     echo "${DOCKER_CREDS_PSW}" | docker login ghcr.io -u ${DOCKER_CREDS_USR} --password-stdin
                                     echo "${OCR_CREDS_PSW}" | docker login container-registry.oracle.com -u ${OCR_CREDS_USR} --password-stdin

--- a/bobs-books/bobbys-books/bobbys-helidon-stock-application/pom.xml
+++ b/bobs-books/bobbys-books/bobbys-helidon-stock-application/pom.xml
@@ -199,6 +199,11 @@
             <artifactId>bobbys-coherence</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.1.63.Final</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/bobs-books/bobbys-books/bobbys-helidon-stock-application/pom.xml
+++ b/bobs-books/bobbys-books/bobbys-helidon-stock-application/pom.xml
@@ -199,11 +199,6 @@
             <artifactId>bobbys-coherence</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport</artifactId>
-            <version>4.1.63.Final</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/bobs-books/bobbys-books/bobbys-helidon-stock-application/pom.xml
+++ b/bobs-books/bobbys-books/bobbys-helidon-stock-application/pom.xml
@@ -201,7 +201,7 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+            <artifactId>netty-transport</artifactId>
             <version>4.1.63.Final</version>
         </dependency>
     </dependencies>

--- a/bobs-books/roberts-books/roberts-helidon-stock-application/pom.xml
+++ b/bobs-books/roberts-books/roberts-helidon-stock-application/pom.xml
@@ -216,6 +216,11 @@
             <artifactId>roberts-coherence</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>4.1.63.Final</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/bobs-books/roberts-books/roberts-helidon-stock-application/pom.xml
+++ b/bobs-books/roberts-books/roberts-helidon-stock-application/pom.xml
@@ -218,7 +218,7 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-transport</artifactId>
+            <artifactId>netty-all</artifactId>
             <version>4.1.63.Final</version>
         </dependency>
     </dependencies>

--- a/bobs-books/roberts-books/roberts-helidon-stock-application/pom.xml
+++ b/bobs-books/roberts-books/roberts-helidon-stock-application/pom.xml
@@ -218,7 +218,7 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+            <artifactId>netty-transport</artifactId>
             <version>4.1.63.Final</version>
         </dependency>
     </dependencies>

--- a/todo-list/setup/wdt_domain.yaml
+++ b/todo-list/setup/wdt_domain.yaml
@@ -9,6 +9,7 @@ topology:
   AdminServerName: 'AdminServer'
   Server:
     'AdminServer':
+      ListenPort: '7001'
 appDeployments:
   Application:
     ToDoApp:


### PR DESCRIPTION
This pull request includes:
1. Addresses VZ-2641 by using netty-transport version 4.1.63.Final
2. Updates the todo-list WDT model to explicitly specify the admin server port to workaround a new issue with WKO 3.2.3
3. Adds temporary sleep to workaround WebLogic Image Tool error when running in parallel