### PR TITLE
todo list README change data source Name

### DIFF
--- a/bobs-books/bobs-bookstore-order-manager/deploy/imagetool-additions
+++ b/bobs-books/bobs-bookstore-order-manager/deploy/imagetool-additions
@@ -6,3 +6,4 @@ python-libs
 curl
 glibc
 glibc-common
+glib2

--- a/todo-list/README.md
+++ b/todo-list/README.md
@@ -102,7 +102,8 @@ required to match the application and database settings from when you started an
     - In the WebLogic Server Administration Console, navigate to Services -> Data Sources.
     - New -> Generic Data Source
     - First page:
-        - JNDI Name: ToDoDB
+        - Name: ToDoDB
+        - JNDI Name: jdbc/ToDoDB
         - Database Type: MySQL
     - Fourth page:
         - Database Name: tododb

--- a/todo-list/README.md
+++ b/todo-list/README.md
@@ -102,7 +102,7 @@ required to match the application and database settings from when you started an
     - In the WebLogic Server Administration Console, navigate to Services -> Data Sources.
     - New -> Generic Data Source
     - First page:
-        - JNDI Name: jdbc/ToDoDB
+        - JNDI Name: ToDoDB
         - Database Type: MySQL
     - Fourth page:
         - Database Name: tododb

--- a/todo-list/setup/imagetool-additions
+++ b/todo-list/setup/imagetool-additions
@@ -6,3 +6,4 @@ python-libs
 curl
 glibc
 glibc-common
+glib2


### PR DESCRIPTION
In the ToDo List Lift-and-Shift Application README.md, under "Create a new WebLogic Server domain":

Adding the missing step of setting the Name to "ToDoDB" when configuring the data source.