### PR TITLE
VZ 5885: Hello Helidon tracing implementation

### DIFF
--- a/hello-helidon/helidon-app-greet-v1/pom.xml
+++ b/hello-helidon/helidon-app-greet-v1/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2020, 2021, Oracle and/or its affiliates. -->
+<!-- Copyright (c) 2020, 2022, Oracle and/or its affiliates. -->
 <!-- Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -39,6 +39,10 @@
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
             <artifactId>helidon-microprofile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.tracing</groupId>
+            <artifactId>helidon-tracing-zipkin</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/hello-helidon/helidon-app-greet-v2/pom.xml
+++ b/hello-helidon/helidon-app-greet-v2/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2020, 2021, Oracle and/or its affiliates. -->
+<!-- Copyright (c) 2020, 2022, Oracle and/or its affiliates. -->
 <!-- Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -39,6 +39,10 @@
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
             <artifactId>helidon-microprofile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.tracing</groupId>
+            <artifactId>helidon-tracing-zipkin</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>


### PR DESCRIPTION
Zipkin tracer implementation was missing.

Before:
```
2022.05.13 17:50:53 INFO io.helidon.tracing.tracerresolver.TracerResolverBuilder Thread[main,5,main]: TracerResolver not configured, tracing is disabled
2022.05.13 17:50:53 WARNING io.helidon.microprofile.tracing.TracingCdiExtension Thread[main,5,main]: helidon-microprofile-tracing is on the classpath, yet there is no tracer implementation library. Tracing uses a no-op tracer. As a result, no tracing will be configured for WebServer and JAX-RS
```

After:
```
2022.05.13 11:03:54 INFO io.helidon.tracing.zipkin.ZipkinTracerBuilder Thread[main,5,main]: Creating Zipkin Tracer for 'HelidonMP' configured with: http://127.0.0.1:9411/api/v2/spans
```