### PR TITLE
VZ-11424: Building bobbys-helidon-stock-application fails without building bobbys-coherence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ org.eclipse.*
 *.iml
 bobs-books/roberts-books/roberts-helidon-stock-application/src/main/resources/web/
 
+bobs-books/bobbys-books/bobbys-front-end/deploy/LICENSE.txt
+bobs-books/bobbys-books/bobbys-front-end/deploy/THIRD_PARTY_LICENSES.txt
+bobs-books/bobbys-books/bobbys-front-end/deploy/archive.zip
+bobs-books/bobbys-books/bobbys-front-end/deploy/imagetool.zip
+bobs-books/bobbys-books/bobbys-front-end/deploy/imagetool/
+bobs-books/bobbys-books/bobbys-front-end/deploy/weblogic-deploy.zip

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,8 +113,7 @@ pipeline {
                                     echo "${DOCKER_CREDS_PSW}" | docker login ghcr.io -u ${DOCKER_CREDS_USR} --password-stdin
                                     cd examples/bobs-books/bobbys-books/bobbys-coherence
                                     mvn -B -s $MAVEN_SETTINGS -Dmaven.compiler.fork=true -Dmaven.compiler.executable=\${JAVA_11_HOME}/bin/javac clean install
-                                    oci os object get -bn ${BUCKET_NAME} --file ${JDK14_BUNDLE} --name ${JDK14_BUNDLE}
-                                    docker build --build-arg JDK_BINARY=${JDK14_BUNDLE} --force-rm=true -f Dockerfile -t ${env.REPO}/${env.BOBBYS_COHERENCE}:${env.VERSION} .
+                                    docker build --force-rm=true -f Dockerfile -t ${env.REPO}/${env.BOBBYS_COHERENCE}:${env.VERSION} .
                                     docker push ${env.REPO}/${env.BOBBYS_COHERENCE}:${env.VERSION}
                                 """
                             }
@@ -137,8 +136,7 @@ pipeline {
                                     echo "${DOCKER_CREDS_PSW}" | docker login ghcr.io -u ${DOCKER_CREDS_USR} --password-stdin
                                     cd examples/bobs-books/bobbys-books/bobbys-helidon-stock-application
                                     mvn -B -s $MAVEN_SETTINGS -Dmaven.compiler.fork=true -Dmaven.compiler.executable=\${JAVA_11_HOME}/bin/javac clean install
-                                    oci os object get -bn ${BUCKET_NAME} --file ${JDK14_BUNDLE} --name ${JDK14_BUNDLE}
-                                    docker build --build-arg JDK_BINARY=${JDK14_BUNDLE} --force-rm=true -f Dockerfile -t ${env.REPO}/${env.BOBBYS_HELIDON}:${env.VERSION} .
+                                    docker build --force-rm=true -f Dockerfile -t ${env.REPO}/${env.BOBBYS_HELIDON}:${env.VERSION} .
                                     docker push ${env.REPO}/${env.BOBBYS_HELIDON}:${env.VERSION}
                                 """
                             }

--- a/bobs-books/bobbys-books/README.md
+++ b/bobs-books/bobbys-books/README.md
@@ -12,11 +12,12 @@ Book store app has two parts right now:
 
 From the root directory: 
 
-Build `bobbys-coherence` followed by `bobbys-helidon-stock-application`  
+Build `bobbys-coherence` first (Note: `bobbys-helidon-stock-application` depends on `bobbys-coherence`)  
 ```
 cd bobbys-coherence
 mvn clean install
 ```
+Build and run `bobbys-helidon-stock-application`
 ```
 cd bobbys-helidon-stock-application
 mvn clean install

--- a/bobs-books/bobbys-books/README.md
+++ b/bobs-books/bobbys-books/README.md
@@ -19,7 +19,7 @@ mvn clean install
 ```
 Build and run `bobbys-helidon-stock-application`
 ```
-cd bobbys-helidon-stock-application
+cd ../bobbys-helidon-stock-application
 mvn clean install
 java -Dbookstore.size=5 -jar target/bobbys-helidon-stock-application.jar
 ```
@@ -36,14 +36,14 @@ java -Dbookstore.size=5 -jar target/bobbys-helidon-stock-application.jar
 
 ### Sample JSON
 
-See `helidon-mp/src/test/book.json`
+See `bobbys-helidon-stock-application/src/test/book.json`
 
 ### Example Curl Commands
 
 ```bash
 curl -H "Content-Type: application/json" \
  -X POST http://localhost:8080/books \
- --data @helidon-mp/target/test-classes/book.json 
+ --data @bobbys-helidon-stock-application/target/test-classes/book.json
  
 curl -H 'Accept: application/json' -X GET http://localhost:8080/books
 
@@ -51,7 +51,7 @@ curl -H 'Accept: application/json' -X GET http://localhost:8080/books/123456
 
 curl -H "Content-Type: application/json" \
  -X PUT http://localhost:8080/books/1234 \
- --data @helidon-mp/target/test-classes/book.json 
+ --data @bobbys-helidon-stock-application/target/test-classes/book.json
  
 curl -X DELETE http://localhost:8080/books/123456
 ```

--- a/bobs-books/bobbys-books/README.md
+++ b/bobs-books/bobbys-books/README.md
@@ -12,10 +12,15 @@ Book store app has two parts right now:
 
 From the root directory: 
 
+Build `bobbys-coherence` followed by `bobbys-helidon-stock-application`  
 ```
+cd bobbys-coherence
 mvn clean install
-cd helidon-mp
-java -Dbookstore.size=5 -jar target/helidon-mp.jar
+```
+```
+cd bobbys-helidon-stock-application
+mvn clean install
+java -Dbookstore.size=5 -jar target/bobbys-helidon-stock-application.jar
 ```
 
 ### REST API

--- a/bobs-books/bobbys-books/bobbys-coherence/Dockerfile
+++ b/bobs-books/bobbys-books/bobbys-coherence/Dockerfile
@@ -13,17 +13,23 @@ RUN yum update -y \
 
 ENV JAVA_HOME=/usr/java
 ENV PATH $JAVA_HOME/bin:$PATH
-ARG JDK_BINARY="${JDK_BINARY:-openjdk-14.0.2_linux-x64_bin.tar.gz}"
-COPY ${JDK_BINARY} jdk.tar.gz
-ENV JDK_DOWNLOAD_SHA256=91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d
+ARG JAVA_URL="${JAVA_URL:-https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL}"
 
-RUN set -eux \
+RUN set -eux; \
+    ARCH="$(uname -m)" && \
+    # Java uses just x64 in the name of the tarball
+    if [ "$ARCH" = "x86_64" ]; \
+        then ARCH="x64"; \
+    fi && \
+    JAVA_PKG="$JAVA_URL"/openjdk-21.0.1_linux-"${ARCH}"_bin.tar.gz ; \
+    JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \
+    curl --output jdk.tgz "$JAVA_PKG" && \
     echo "Checking JDK hash"; \
-    echo "${JDK_DOWNLOAD_SHA256} *jdk.tar.gz" | sha256sum --check -; \
+    echo "$JAVA_SHA256" jdk.tgz | sha256sum --check - && \
     echo "Installing JDK"; \
-    mkdir -p "$JAVA_HOME"; \
-    tar xzf jdk.tar.gz --directory "${JAVA_HOME}" --strip-components=1; \
-    rm -f jdk.tar.gz;
+    mkdir -p "$JAVA_HOME" && \
+    tar xzf jdk.tgz --directory "${JAVA_HOME}" --strip-components=1; \
+    rm -f jdk.tgz;
 
 COPY target/libs/*.jar /app/libs/
 COPY target/*.jar /app/classpath/

--- a/bobs-books/bobbys-books/bobbys-coherence/build.sh
+++ b/bobs-books/bobbys-books/bobbys-coherence/build.sh
@@ -1,8 +1,9 @@
-#!/bin/bash
-# Copyright (c) 2020, Oracle and/or its affiliates.
+#!/usr/bin/env bash
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-TAG=${1:-test}
+TAG=${TAG:-test}
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 
 mvn clean install
-docker build --force-rm=true -t ghcr.io/verrazzano/example-bobbys-coherence:${TAG} .
+"${CONTAINER_RUNTIME}" build --force-rm=true -t ghcr.io/verrazzano/example-bobbys-coherence:"${TAG}" .

--- a/bobs-books/bobbys-books/bobbys-coherence/build.sh
+++ b/bobs-books/bobbys-books/bobbys-coherence/build.sh
@@ -4,6 +4,8 @@
 
 TAG=${TAG:-test}
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+REPOSITORY="${REPOSITORY:-ghcr.io/verrazzano}"
+IMAGE_NAME="${IMAGE_NAME:-example-bobbys-coherence}"
 
 mvn clean install
-"${CONTAINER_RUNTIME}" build --force-rm=true -t ghcr.io/verrazzano/example-bobbys-coherence:"${TAG}" .
+"${CONTAINER_RUNTIME}" build --force-rm=true -t "${REPOSITORY}"/"${IMAGE_NAME}":"${TAG}" .

--- a/bobs-books/bobbys-books/bobbys-coherence/pom.xml
+++ b/bobs-books/bobbys-books/bobbys-coherence/pom.xml
@@ -13,8 +13,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <argLine>-Dfile.encoding=UTF-8</argLine>

--- a/bobs-books/bobbys-books/bobbys-coherence/pom.xml
+++ b/bobs-books/bobbys-books/bobbys-coherence/pom.xml
@@ -13,8 +13,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <argLine>-Dfile.encoding=UTF-8</argLine>

--- a/bobs-books/bobbys-books/bobbys-helidon-stock-application/Dockerfile
+++ b/bobs-books/bobbys-books/bobbys-helidon-stock-application/Dockerfile
@@ -13,7 +13,6 @@ RUN yum update -y \
 
 ENV JAVA_HOME=/usr/java
 ENV PATH $JAVA_HOME/bin:$PATH
-ARG JDK_BINARY="${JDK_BINARY:-openjdk-14.0.2_linux-x64_bin.tar.gz}"
 ARG JAVA_URL="${JAVA_URL:-https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL}"
 
 RUN set -eux; \

--- a/bobs-books/bobbys-books/bobbys-helidon-stock-application/Dockerfile
+++ b/bobs-books/bobbys-books/bobbys-helidon-stock-application/Dockerfile
@@ -14,17 +14,23 @@ RUN yum update -y \
 ENV JAVA_HOME=/usr/java
 ENV PATH $JAVA_HOME/bin:$PATH
 ARG JDK_BINARY="${JDK_BINARY:-openjdk-14.0.2_linux-x64_bin.tar.gz}"
-COPY ${JDK_BINARY} jdk.tar.gz
-ENV JDK_DOWNLOAD_SHA256=91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d
+ARG JAVA_URL="${JAVA_URL:-https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL}"
 
-RUN set -eux \
+RUN set -eux; \
+    ARCH="$(uname -m)" && \
+    # Java uses just x64 in the name of the tarball
+    if [ "$ARCH" = "x86_64" ]; \
+        then ARCH="x64"; \
+    fi && \
+    JAVA_PKG="$JAVA_URL"/openjdk-21.0.1_linux-"${ARCH}"_bin.tar.gz ; \
+    JAVA_SHA256="$(curl "$JAVA_PKG".sha256)" ; \
+    curl --output jdk.tgz "$JAVA_PKG" && \
     echo "Checking JDK hash"; \
-    echo "${JDK_DOWNLOAD_SHA256} *jdk.tar.gz" | sha256sum --check -; \
+    echo "$JAVA_SHA256" jdk.tgz | sha256sum --check - && \
     echo "Installing JDK"; \
-    mkdir -p "$JAVA_HOME"; \
-    tar xzf jdk.tar.gz --directory "${JAVA_HOME}" --strip-components=1; \
-    rm -f jdk.tar.gz;
-
+    mkdir -p "$JAVA_HOME" && \
+    tar xzf jdk.tgz --directory "${JAVA_HOME}" --strip-components=1; \
+    rm -f jdk.tgz;
 
 COPY target/libs/*.jar /app/libs/
 COPY target/*.jar /app/

--- a/bobs-books/bobbys-books/bobbys-helidon-stock-application/build_local.sh
+++ b/bobs-books/bobbys-books/bobbys-helidon-stock-application/build_local.sh
@@ -1,8 +1,9 @@
-#!/bin/bash
-# Copyright (c) 2020, Oracle and/or its affiliates.
+#!/usr/bin/env bash
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-TAG=${1:-test}
+TAG=${TAG:-test}
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 
 mvn clean install
-docker build --force-rm=true -f Dockerfile -t ghcr.io/verrazzano/example-bobbys-helidon-stock-application:${TAG} .
+"${CONTAINER_RUNTIME}" build --force-rm=true -f Dockerfile -t ghcr.io/verrazzano/example-bobbys-helidon-stock-application:${TAG} .


### PR DESCRIPTION
- Use jdk 21. (Note: jdk 14 is now legacy). Updated dockerfiles so that containerized builds can work without user requiring to give to jdk tar file argument for docker builds.
- Updated readme.